### PR TITLE
[WIP] sort replica randomly to distribute leader node

### DIFF
--- a/kafka-reassign-optimizer.py
+++ b/kafka-reassign-optimizer.py
@@ -33,6 +33,7 @@ import math
 from itertools import groupby, product
 import json
 import pulp
+import random
 
 BALANCE_MIN_FACTOR = 0.9
 BALANCE_MAX_FACTOR = 1.1
@@ -268,6 +269,9 @@ if __name__ == '__main__':
         for b in reassignment_config.brokers:
             if int(proposed_assignment[(t,p,b)].value()) == 1:
                 replicas.append(b)
+        # currently proposed_assignment returns sorted replica list and this is quick hack to distribute leader node and preffered node.
+        # TODO: select leaders according to the current status and the cluster balance.
+        random.shuffle(replicas)
         proposed_assignment_json["partitions"].append({
             "topic": t,
             "partition": int(p),

--- a/kafka-reassign-optimizer.py
+++ b/kafka-reassign-optimizer.py
@@ -263,7 +263,7 @@ if __name__ == '__main__':
 
     logger.info("")
     logger.info("# Partition Replica Assignment (copy it and input to kafka-reassign-partition.sh)")
-    proposed_assignment_json = { 'vertion': 1, 'partitions':[] }
+    proposed_assignment_json = { 'version': 1, 'partitions':[] }
     for (t, p) in reassignment_config.tps:
         replicas = []
         for b in reassignment_config.brokers:


### PR DESCRIPTION
Currently, this tool returns `replica` in sorted order and if you do `rebalance` or `auto.leader.rebalance.enable=true` in kafka cluster,  leader assignment is not equally distributed and broker having small id becomes leader much more than broker having big ids.
And this is a quick hack to prevent it.
