### PR TITLE
Topic offset as weight

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val root = (project in file(".")).
       Scalaz.core,
       Kafka.kafka,
       Optimus.core,
-      Optimus.solverLp
+      Optimus.solverLp// ,
+      // Optimus.oj
     ) ++ Circe.all ++ Seq(
       scalaTest % Test
     ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
     val version = Versions.optimus
     val core =  "com.github.vagmcs" %% "optimus" % version
     val solverLp = "com.github.vagmcs" %% "optimus-solver-lp" % version
+    val oj = "com.github.vagmcs" %% "optimus-solver-oj" % version
   }
 
   object Scalaz {

--- a/src/main/scala/com/github/everpeace/kafka/reassign_optimizer/Main.scala
+++ b/src/main/scala/com/github/everpeace/kafka/reassign_optimizer/Main.scala
@@ -1,7 +1,6 @@
 package com.github.everpeace.kafka.reassign_optimizer
 
 import com.github.everpeace.kafka.reassign_optimizer.ReassignOptimizationProblem.Solution
-import com.github.everpeace.kafka.reassign_optimizer.util.Tabulator
 import kafka.admin._
 import kafka.common.TopicAndPartition
 import kafka.utils.ZkUtils
@@ -23,7 +22,7 @@ object Main extends App {
   import config._
 
   val zk = ZkUtils(zkString, 30000, 30000, JaasUtils.isZkSecurityEnabled)
-  val partitionWeights = (_: TopicAndPartition) => 1
+  val partitionWeights = weightType.partitionWeight(zk)
   val topicMetas = AdminUtils.fetchTopicMetadataFromZk(
     if (topics.isEmpty) zk.getAllTopics().toSet else topics,
     zk

--- a/src/main/scala/com/github/everpeace/kafka/reassign_optimizer/ReassignOptimizationProblem.scala
+++ b/src/main/scala/com/github/everpeace/kafka/reassign_optimizer/ReassignOptimizationProblem.scala
@@ -95,6 +95,15 @@ case class ReassignOptimizationProblem(topicPartitionInfos: List[TopicPartitionI
     move * 0.5
   }
 
+//  val `distribution of broker weights`: Expression = {
+//    val brokerWeights = assignmentVariables.groupBy(_._1._3).mapValues(_.foldLeft(Const(0.0): Expression)({
+//        case (accum, (tp, v)) => accum + (v * partitionWeights((tp._1, tp._2)))
+//
+//    })).values.toList
+//    val avg = brokerWeights.fold(Const(0.0): Expression)(_ + _) * (1.0d / brokerWeights.length)
+//    brokerWeights.map(w => (avg - w) * (avg - w) ).fold(Const(0.0): Expression)(_ + _) * (1.0d / brokerWeights.length)
+//  }
+
   //
   // constraints
   //
@@ -145,6 +154,7 @@ case class ReassignOptimizationProblem(topicPartitionInfos: List[TopicPartitionI
 
   def solve(): Solution = {
 
+//    minimize(`total amount of replica movement` + `distribution of broker weights`)
     minimize(`total amount of replica movement`)
     add(`C1: total replica weight doesn't change`)
     for {


### PR DESCRIPTION
This fixes #5.

introduced `--weight-type`.  user can choose `constant` or `offset`.  in `constant` , any topic partition weight as 1.  in `offset` , weight of topic partition will be average of offset of all replicas.

help:
```
$ docker run -it --rm --net host everpeace/kafka-reassign-optimizer --help
...
 --weight-type constant|offset
                           type of topic-partition weight. (default = constant)
...
```

example:
```
$ docker run -it --rm --net host everpeace/kafka-reassign-optimizer --print-assignment --zookeeper 127.0.0.1:2181 --brokers 1,2,3,4,5 --weight-type offset --balanced-factor-min 0.6 --balanced-factor-max 1.2

#
# Summary of Current Partition Assignment
#
Total Replica Weights: 174
Current Broker Set: 1,2,3
Broker Weights: Map(1 -> 58, 2 -> 58, 3 -> 58, 4 -> 0, 5 -> 0)
Current Partition Assignment:

     broker     1     2     3    4    5              

   [tp1, 0]    20    20   ⚐20    0    0   (RF = 3)   
   [tp1, 1]   ⚐19    19    19    0    0   (RF = 3)   
   [tp1, 2]    19   ⚐19    19    0    0   (RF = 3)   

     weight    58    58    58    0    0              
          ⚐   leader partition        

#
# Finding Optimal Partition Assignment 
# let's find well balanced but minimum partition movements
#
  ______________________     ______            
  ___  /___  __ \_  ___/________  /__   ______ 
  __  / __  /_/ /____ \_  __ \_  /__ | / /  _ \
  _  /___  ____/____/ // /_/ /  / __ |/ //  __/
  /_____/_/     /____/ \____//_/  _____/ \___/ 

Model lpSolve: 14x15
Configuring variable bounds...
Adding objective function...
Creating constraints: Added 14 constraints in 3ms
Solving...
Solution status is Optimal

#
# Summary of Proposed Partition Assignment
#
Is Solution Optimal?: Optimal
Total Replica Weights: 174
Replica Move Amount: 58
New Broker Set: 1,2,3,4,5
Broker Weights: Map(1 -> 39, 2 -> 38, 3 -> 39, 4 -> 38, 5 -> 20)
Proposed Partition Assignment:

     broker     1     2     3     4     5                                   

   [tp1, 0]    20     0   ⚐20     0    20   (RF = 3)   (move amount = 20)   
   [tp1, 1]   ⚐19    19     0    19     0   (RF = 3)   (move amount = 19)   
   [tp1, 2]     0   ⚐19    19    19     0   (RF = 3)   (move amount = 19)   

     weight    39    38    39    38    20                                   
          ⚐   leader partition                            

#
# Proposed Assignment
# (You can save below json and pass it to kafka-reassign-partition command)
#
{
  "version" : 1,
  "partitions" : [
    {
      "topic" : "tp1",
      "partition" : 0,
      "replicas" : [
        3,
        1,
        5
      ]
    },
    {
      "topic" : "tp1",
      "partition" : 1,
      "replicas" : [
        1,
        4,
        2
      ]
    },
    {
      "topic" : "tp1",
      "partition" : 2,
      "replicas" : [
        2,
        4,
        3
      ]
    }
  ]
}
```